### PR TITLE
Add GitHub Actions workflow to run main.py

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,32 @@
+name: Run main.py
+on:
+  workflow_dispatch:
+    inputs:
+      id:
+        description: 'ID to pass to main.py'
+        required: true
+        type: secret
+
+jobs:
+  run-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies if present
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Run main.py with secret input
+        env:
+          ID: ${{ github.event.inputs.id }}
+        run: |
+          echo "$ID" | python main.py


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to enable manually running `main.py` with a secret input parameter. The workflow sets up the Python environment, installs dependencies, and securely passes the input to the script.

**Continuous Integration / Automation:**

* Added `.github/workflows/dispatch.yml` to define a `workflow_dispatch` action for manually triggering the workflow and passing a secret `id` input to `main.py`.
* Configured steps to check out the repository, set up Python 3, install dependencies (including those from `requirements.txt` if present), and run `main.py` with the secret input.